### PR TITLE
change: port to pyo3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 divvunspell = { git = "https://github.com/divvun/divvunspell", branch = "main", features = ["compression"] }
 
-[dependencies.cpython]
-version = "0.5"
+[dependencies.pyo3]
+version = "0.12.4"
 features = ["extension-module"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use pyo3::prelude::*;
 use divvunspell::{archive, speller};
+use pyo3::prelude::*;
 
 #[pymodule]
 fn divvunspell(_py: Python, m: &PyModule) -> PyResult<()> {
@@ -40,6 +40,9 @@ impl Speller {
     fn suggest(&self, word: String) -> PyResult<Vec<(String, f32)>> {
         let speller = Arc::clone(&self.speller);
         let results = speller.suggest(&word);
-        Ok(results.into_iter().map(|x| (x.value.to_string(), x.weight)).collect::<Vec<_>>())
+        Ok(results
+            .into_iter()
+            .map(|x| (x.value.to_string(), x.weight))
+            .collect::<Vec<_>>())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,26 @@ use std::sync::Arc;
 use divvunspell::{archive, speller};
 use pyo3::prelude::*;
 
+/// Use spell checker archives compatible with the [divvunspell] project.
+///
+/// divvunspell is intended to be a Rust implementation of [hfst-ospell],
+/// so `.zhfst` speller archives should work.
+///
+/// To get started, open a speller archive:
+///
+///     from divvunspell import SpellerArchive
+///
+///     archive = SpellerArchive("path/to/my-spellers.zhfst")
+///     speller = archive.speller()
+///
+/// Then use the speller to suggest corrections!
+///
+///     suggestions = speller.suggest("teh")
+///     # should give you something like:
+///     # [('the', 1.0), ('ten', 4.0)]
+///
+/// [divvunspell]: https://github.com/divvun/divvunspell
+/// [hfst-ospell]: https://github.com/hfst/hfst-ospell
 #[pymodule]
 fn divvunspell(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<SpellerArchive>()?;
@@ -11,6 +31,12 @@ fn divvunspell(_py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
+/// Opens a speller archive, such as a .zhfst file
+///
+/// Usage:
+///
+/// >>> ar = SpellerArchive("path/to/my-speller.zhfst")
+/// >>> speller = ar.speller()
 #[pyclass]
 struct SpellerArchive {
     archive: Arc<dyn archive::SpellerArchive + Send + Sync>,
@@ -24,12 +50,19 @@ impl SpellerArchive {
         Ok(SpellerArchive { archive: ar })
     }
 
+    /// Returns a Speller instance. You probably want this.
     fn speller(&self) -> PyResult<Speller> {
         let speller = self.archive.speller();
         Ok(Speller { speller })
     }
 }
 
+/// Speller that can suggest spelling corrections.
+///
+/// Usage:
+///
+/// >>> speller.suggest("teh")
+/// [('the', 1.0,), ('ten', 1.5), ('tea', 1.75), ('tee', 2.0)]
 #[pyclass]
 struct Speller {
     speller: Arc<dyn speller::Speller + Send + Sync>,
@@ -37,6 +70,13 @@ struct Speller {
 
 #[pymethods]
 impl Speller {
+    /// Given a possibly misspelled word, returns a list spelling suggestions.
+    /// Each suggestion is a tuple of (correction, weight).
+    ///
+    /// The correction is a string that could replace the given word. Note
+    /// that some spellers may suggest the input (no change). The weight is a
+    /// floating point number from 0 to infinity. A smaller value means a
+    /// more likely suggestion. A bigger value is a less-likely suggestion.
     fn suggest(&self, word: String) -> PyResult<Vec<(String, f32)>> {
         let speller = Arc::clone(&self.speller);
         let results = speller.suggest(&word);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,45 @@
 use std::sync::Arc;
 
-use cpython::{PyResult, py_class, py_module_initializer};
+use pyo3::prelude::*;
 use divvunspell::{archive, speller};
 
-py_module_initializer!(divvunspell, initdivvunspell, PyInit_divvunspell, |py, m| {
-    m.add_class::<SpellerArchive>(py)?;
-    m.add_class::<Speller>(py)?;
+#[pymodule]
+fn divvunspell(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<SpellerArchive>()?;
+    m.add_class::<Speller>()?;
+
     Ok(())
-});
+}
 
-py_class!(class SpellerArchive |py| {
-    data archive: Arc<dyn archive::SpellerArchive + Send + Sync>;
+#[pyclass]
+struct SpellerArchive {
+    archive: Arc<dyn archive::SpellerArchive + Send + Sync>,
+}
 
-    def __new__(_cls, path: String) -> PyResult<Self> {
+#[pymethods]
+impl SpellerArchive {
+    #[new]
+    fn new(path: String) -> PyResult<Self> {
         let ar = archive::open(std::path::Path::new(&path)).unwrap();
-        Self::create_instance(py, ar)
+        Ok(SpellerArchive { archive: ar })
     }
 
-    def speller(&self) -> PyResult<Speller> {
-        let speller = self.archive(py).speller();
-        Speller::create_instance(py, speller)
+    fn speller(&self) -> PyResult<Speller> {
+        let speller = self.archive.speller();
+        Ok(Speller { speller })
     }
-});
+}
 
-py_class!(class Speller |py| {
-    data speller: Arc<dyn speller::Speller + Send + Sync>;
+#[pyclass]
+struct Speller {
+    speller: Arc<dyn speller::Speller + Send + Sync>,
+}
 
-    def suggest(&self, word: String) -> PyResult<Vec<(String, f32)>> {
-        let speller = Arc::clone(&self.speller(py));
+#[pymethods]
+impl Speller {
+    fn suggest(&self, word: String) -> PyResult<Vec<(String, f32)>> {
+        let speller = Arc::clone(&self.speller);
         let results = speller.suggest(&word);
         Ok(results.into_iter().map(|x| (x.value.to_string(), x.weight)).collect::<Vec<_>>())
     }
-});
+}


### PR DESCRIPTION
This ports the conversion to [pyo3] for a few reasons:

 - It was easier for to me to figure out how to add Python docstrings within the Rust code with pyo3
 - those `py_module_initializer!`/`py_class!` macros are an _abomination_