### PR TITLE
docs: add docstrings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,26 @@ use std::sync::Arc;
 use divvunspell::{archive, speller};
 use pyo3::prelude::*;
 
+/// Use spell checker archives compatible with the [divvunspell] project.
+///
+/// divvunspell is intended to be a Rust implementation of [hfst-ospell],
+/// so `.zhfst` speller archives should work.
+///
+/// To get started, open a speller archive:
+///
+///     from divvunspell import SpellerArchive
+///
+///     archive = SpellerArchive("path/to/my-spellers.zhfst")
+///     speller = archive.speller()
+///
+/// Then use the speller to suggest corrections!
+///
+///     suggestions = speller.suggest("teh")
+///     # should give you something like:
+///     # [('the', 1.0), ('ten', 4.0)]
+///
+/// [divvunspell]: https://github.com/divvun/divvunspell
+/// [hfst-ospell]: https://github.com/hfst/hfst-ospell
 #[pymodule]
 fn divvunspell(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<SpellerArchive>()?;
@@ -11,6 +31,12 @@ fn divvunspell(_py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
+/// Opens a speller archive, such as a .zhfst file
+///
+/// Usage:
+///
+/// >>> ar = SpellerArchive("path/to/my-speller.zhfst")
+/// >>> speller = ar.speller()
 #[pyclass]
 struct SpellerArchive {
     archive: Arc<dyn archive::SpellerArchive + Send + Sync>,
@@ -24,12 +50,19 @@ impl SpellerArchive {
         Ok(SpellerArchive { archive: ar })
     }
 
+    /// Returns a Speller instance. You probably want this.
     fn speller(&self) -> PyResult<Speller> {
         let speller = self.archive.speller();
         Ok(Speller { speller })
     }
 }
 
+/// Speller that can suggest spelling corrections.
+///
+/// Usage:
+///
+/// >>> speller.suggest("teh")
+/// [('the', 1.0,), ('ten', 1.5), ('tea', 1.75), ('tee', 2.0)]
 #[pyclass]
 struct Speller {
     speller: Arc<dyn speller::Speller + Send + Sync>,
@@ -37,6 +70,13 @@ struct Speller {
 
 #[pymethods]
 impl Speller {
+    /// Given a possibly misspelled word, returns a list spelling suggestions.
+    /// Each suggestion is a tuple of (correction, weight).
+    ///
+    /// The correction is a string that could replace the given word. Note
+    /// that some spellers may suggest the input (no change). The weight is a
+    /// floating point number from 0 to infinity. A smaller value means a
+    /// more likely suggestion. A bigger value is a less-likely suggestion.
     fn suggest(&self, word: String) -> PyResult<Vec<(String, f32)>> {
         let speller = Arc::clone(&self.speller);
         let results = speller.suggest(&word);


### PR DESCRIPTION
With these docstrings, it produces the following documentation (run `python3 -m pydoc divvunspell`):

```
Help on module divvunspell:

NAME
    divvunspell - Use spell checker archives compatible with the [divvunspell] project.

DESCRIPTION
    divvunspell is intended to be a Rust implementation of [hfst-ospell],
    so `.zhfst` speller archives should work.
    
    To get started, open a speller archive:
    
        from divvunspell import SpellerArchive
    
        archive = SpellerArchive("path/to/my-spellers.zhfst")
        speller = archive.speller()
    
    Then use the speller to suggest corrections!
    
        suggestions = speller.suggest("teh")
        # should give you something like:
        # [('the', 1.0), ('ten', 4.0)]
    
    [divvunspell]: https://github.com/divvun/divvunspell
    [hfst-ospell]: https://github.com/hfst/hfst-ospell

CLASSES
    builtins.object
        builtins.Speller
        builtins.SpellerArchive
    
    class Speller(object)
     |  Speller that can suggest spelling corrections.
     |  
     |  Usage:
     |  
     |  >>> speller.suggest("teh")
     |  [('the', 1.0,), ('ten', 1.5), ('tea', 1.75), ('tee', 2.0)]
     |  
     |  Methods defined here:
     |  
     |  suggest(...)
     |      Given a possibly misspelled word, returns a list spelling suggestions.
     |      Each suggestion is a tuple of (correction, weight).
     |      
     |      The correction is a string that could replace the given word. Note
     |      that some spellers may suggest the input (no change). The weight is a
     |      floating point number from 0 to infinity. A smaller value means a
     |      more likely suggestion. A bigger value is a less-likely suggestion.
    
    class SpellerArchive(object)
     |  Opens a speller archive, such as a .zhfst file
     |  
     |  Usage:
     |  
     |  >>> ar = SpellerArchive("path/to/my-speller.zhfst")
     |  >>> speller = ar.speller()
     |  
     |  Methods defined here:
     |  
     |  speller(...)
     |      Returns a Speller instance. You probably want this.
     |  
     |  ----------------------------------------------------------------------
     |  Static methods defined here:
     |  
     |  __new__(*args, **kwargs) from builtins.type
     |      Create and return a new object.  See help(type) for accurate signature.

DATA
    __all__ = ['__doc__', 'SpellerArchive', 'Speller']

FILE
    /Users/santoseadmin/Work/divvunspell-sdk-python/.venv/lib/python3.8/site-packages/divvunspell.cpython-38-darwin.so
```

(I couldn't figure out how to specify the docs for `__new__` ;_;)